### PR TITLE
Implement Local Summary History Panel

### DIFF
--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -153,76 +153,85 @@ function SummaryPageContent() {
   );
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-3xl">
-      <div className="flex justify-between items-center mb-4">
-        <h1 className="text-2xl font-bold">DigestIt</h1>
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => setIsHistoryPanelOpen(true)}
-          aria-label="View History"
+    <div className="flex flex-col min-h-screen justify-center items-center px-4 py-8">
+      <div className="container max-w-3xl">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-3xl font-bold tracking-tight text-center flex-grow">
+            Reddit Thread Summarizer
+          </h1>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => setIsHistoryPanelOpen(true)}
+            aria-label="View History"
+            className="ml-4"
+          >
+            <History className="h-5 w-5" />
+          </Button>
+        </div>
+
+        <p className="text-muted-foreground text-center mb-6">
+          Paste the URL of a Reddit thread below to get a quick summary.
+        </p>
+
+        <form
+          onSubmit={form.handleSubmit(handleSubmit)}
+          className="flex gap-2 mb-6"
         >
-          <History className="h-5 w-5" />
-        </Button>
+          <Input
+            {...form.register("url")}
+            placeholder="Paste Reddit thread URL (e.g., reddit.com/r/.../comments/...)"
+            className="flex-grow"
+            disabled={getSummaryMutation.isPending}
+          />
+          <Button
+            type="submit"
+            disabled={getSummaryMutation.isPending || !form.formState.isValid}
+          >
+            {getSummaryMutation.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
+            {getSummaryMutation.isPending ? "Summarizing..." : "Summarize"}
+          </Button>
+        </form>
+
+        {form.formState.errors.url && (
+          <Alert variant="destructive" className="mb-6">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Invalid URL</AlertTitle>
+            <AlertDescription>
+              {form.formState.errors.url.message}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {getSummaryMutation.error && (
+          <Alert variant="destructive" className="mb-6">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>
+              {getSummaryMutation.error.message ||
+                "An unknown error occurred while fetching the summary."}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {(getSummaryMutation.isPending || currentSummaryData) && (
+          <SummaryCard
+            summaryData={currentSummaryData!}
+            submittedUrl={submittedUrl}
+            isLoading={getSummaryMutation.isPending}
+            revealedSections={revealedSections}
+            sectionOrder={sectionOrder}
+            renderChunk={renderChunk}
+          />
+        )}
+
+        <HistoryPanel
+          isOpen={isHistoryPanelOpen}
+          onOpenChange={setIsHistoryPanelOpen}
+        />
       </div>
-
-      <form
-        onSubmit={form.handleSubmit(handleSubmit)}
-        className="flex gap-2 mb-6"
-      >
-        <Input
-          {...form.register("url")}
-          placeholder="Paste Reddit thread URL (e.g., reddit.com/r/.../comments/...)"
-          className="flex-grow"
-          disabled={getSummaryMutation.isPending}
-        />
-        <Button
-          type="submit"
-          disabled={getSummaryMutation.isPending || !form.formState.isValid}
-        >
-          {getSummaryMutation.isPending ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-          ) : null}
-          {getSummaryMutation.isPending ? "Summarizing..." : "Summarize"}
-        </Button>
-      </form>
-
-      {form.formState.errors.url && (
-        <Alert variant="destructive" className="mb-6">
-          <AlertCircle className="h-4 w-4" />
-          <AlertTitle>Invalid URL</AlertTitle>
-          <AlertDescription>
-            {form.formState.errors.url.message}
-          </AlertDescription>
-        </Alert>
-      )}
-
-      {getSummaryMutation.error && (
-        <Alert variant="destructive" className="mb-6">
-          <AlertCircle className="h-4 w-4" />
-          <AlertTitle>Error</AlertTitle>
-          <AlertDescription>
-            {getSummaryMutation.error.message ||
-              "An unknown error occurred while fetching the summary."}
-          </AlertDescription>
-        </Alert>
-      )}
-
-      {(getSummaryMutation.isPending || currentSummaryData) && (
-        <SummaryCard
-          summaryData={currentSummaryData!}
-          submittedUrl={submittedUrl}
-          isLoading={getSummaryMutation.isPending}
-          revealedSections={revealedSections}
-          sectionOrder={sectionOrder}
-          renderChunk={renderChunk}
-        />
-      )}
-
-      <HistoryPanel
-        isOpen={isHistoryPanelOpen}
-        onOpenChange={setIsHistoryPanelOpen}
-      />
     </div>
   );
 }

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -16,6 +16,7 @@ import SummaryCard from "@/components/summary/SummaryCard";
 import { HistoryProvider, useHistory } from "@/contexts/HistoryContext";
 import HistoryPanel from "@/components/history/HistoryPanel";
 import { HistoryEntry } from "@/lib/types/historyTypes";
+import SimpleHeader from "@/components/SimpleHeader";
 
 const summarySchema = z.object({
   url: z.string().url({ message: "Please enter a valid URL." }),
@@ -62,6 +63,7 @@ function SummaryPageContent() {
       selectHistoryEntry(null);
       handleSubmit({ url });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams, form.setValue]);
 
   useEffect(() => {
@@ -73,6 +75,7 @@ function SummaryPageContent() {
       getSummaryMutation.reset();
       selectHistoryEntry(null);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [urlFromParams]);
 
   useEffect(() => {
@@ -153,18 +156,14 @@ function SummaryPageContent() {
   );
 
   return (
-    <div className="flex flex-col min-h-screen justify-center items-center px-4 py-8">
+    <div className="flex flex-col min-h-screen items-center px-4 py-8">
       <div className="container max-w-3xl">
-        <div className="flex justify-between items-center mb-6">
-          <h1 className="text-3xl font-bold tracking-tight text-center flex-grow">
-            Reddit Thread Summarizer
-          </h1>
+        <div className="flex justify-end mb-4">
           <Button
             variant="outline"
             size="icon"
             onClick={() => setIsHistoryPanelOpen(true)}
             aria-label="View History"
-            className="ml-4"
           >
             <History className="h-5 w-5" />
           </Button>
@@ -239,6 +238,7 @@ function SummaryPageContent() {
 export default function SummaryPage() {
   return (
     <HistoryProvider>
+      <SimpleHeader />
       <SummaryPageContent />
     </HistoryProvider>
   );

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -158,12 +158,16 @@ function SummaryPageContent() {
   return (
     <div className="flex flex-col min-h-screen items-center px-4 py-8">
       <div className="container max-w-3xl">
-        <div className="flex justify-end mb-4">
+        <div className="flex justify-center items-center relative mb-6">
+          <h1 className="text-3xl font-bold tracking-tight">
+            Reddit Thread Summarizer
+          </h1>
           <Button
             variant="outline"
             size="icon"
             onClick={() => setIsHistoryPanelOpen(true)}
             aria-label="View History"
+            className="absolute right-0 top-1/2 -translate-y-1/2"
           >
             <History className="h-5 w-5" />
           </Button>

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -1,17 +1,27 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import SimpleHeader from "@/components/SimpleHeader";
-import { Loader2 } from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Loader2, AlertCircle, History } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
 import { trpc } from "@/lib/trpc";
-import {
-  SummaryData,
-  SummaryDataKey,
-  TopCommentData,
-} from "@/lib/types/summaryTypes";
-import SummaryForm from "@/components/summary/SummaryForm";
-import SummaryCard from "@/components/summary/SummaryCard";
+import { SummaryData, SummaryDataKey } from "@/lib/types/summaryTypes";
 import { renderChunk } from "@/components/summary/SummaryChunks";
+import SummaryCard from "@/components/summary/SummaryCard";
+import { HistoryProvider, useHistory } from "@/contexts/HistoryContext";
+import HistoryPanel from "@/components/history/HistoryPanel";
+import { HistoryEntry } from "@/lib/types/historyTypes";
+
+const summarySchema = z.object({
+  url: z.string().url({ message: "Please enter a valid URL." }),
+});
+
+type SummaryFormValues = z.infer<typeof summarySchema>;
 
 const sectionOrder: SummaryDataKey[] = [
   "quickGlance",
@@ -23,134 +33,204 @@ const sectionOrder: SummaryDataKey[] = [
   "links",
 ];
 
-export default function SummaryPage() {
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+function SummaryPageContent() {
+  const { addHistoryEntry, selectedEntry, selectHistoryEntry } = useHistory();
+  const [isHistoryPanelOpen, setIsHistoryPanelOpen] = useState(false);
+
+  const searchParams = useSearchParams();
+  const [urlFromParams, setUrlFromParams] = useState<string | null>(null);
+  const [currentSummaryData, setCurrentSummaryData] =
+    useState<SummaryData | null>(null);
   const [submittedUrl, setSubmittedUrl] = useState<string | null>(null);
   const [revealedSections, setRevealedSections] = useState<string[]>([]);
-  const [summaryData, setSummaryData] = useState<SummaryData | null>(null);
-  const timeoutsRef = useRef<NodeJS.Timeout[]>([]);
+  const [revealIndex, setRevealIndex] = useState(0);
+
+  const form = useForm<SummaryFormValues>({
+    resolver: zodResolver(summarySchema),
+    defaultValues: {
+      url: "",
+    },
+  });
 
   const getSummaryMutation = trpc.reddit.getSummaryFromUrl.useMutation();
 
   useEffect(() => {
-    return () => {
-      timeoutsRef.current.forEach(clearTimeout);
-    };
-  }, []);
+    const url = searchParams.get("url");
+    if (url) {
+      setUrlFromParams(url);
+      form.setValue("url", url);
+      selectHistoryEntry(null);
+      handleSubmit({ url });
+    }
+  }, [searchParams, form.setValue]);
 
   useEffect(() => {
-    if (summaryData) {
-      setIsLoading(false);
-
-      timeoutsRef.current.forEach(clearTimeout);
-      timeoutsRef.current = [];
-      setRevealedSections([]);
-
-      let delay = 100;
-      const delayIncrement = 200;
-
-      sectionOrder.forEach((sectionKey) => {
-        const sectionData = summaryData[sectionKey];
-
-        // Check if the section should be revealed
-        let shouldReveal = false;
-        if (sectionData) {
-          if (Array.isArray(sectionData)) {
-            shouldReveal = sectionData.length > 0;
-          } else if (
-            sectionKey === "topComment" ||
-            sectionKey === "bestComment"
-          ) {
-            // For comment sections, check if the object exists AND has text
-            shouldReveal =
-              typeof sectionData === "object" &&
-              sectionData !== null &&
-              !!(sectionData as TopCommentData).text;
-          } else {
-            // For other non-array sections (quickGlance, stats, sentiment)
-            shouldReveal = true; // Assume they should be shown if data exists
-          }
-        }
-
-        if (shouldReveal) {
-          const timeoutId = setTimeout(() => {
-            setRevealedSections((prev) => [...prev, sectionKey]);
-          }, delay);
-          timeoutsRef.current.push(timeoutId);
-          delay += delayIncrement;
-        }
-      });
-    }
-  }, [summaryData]);
-
-  const handleSummarize = async (redditUrl: string) => {
-    console.log(`Frontend: handleSummarize called with URL: '${redditUrl}'`);
-    setError(null);
-    setSubmittedUrl(null);
-    setSummaryData(null);
-    setRevealedSections([]);
-    timeoutsRef.current.forEach(clearTimeout);
-    timeoutsRef.current = [];
-    setIsLoading(true);
-
-    setSubmittedUrl(redditUrl);
-
-    try {
-      const summaryResult = await getSummaryMutation.mutateAsync({ redditUrl });
-
-      console.log("Frontend: Received summary data:", summaryResult);
-      setSummaryData(summaryResult);
-    } catch (err: any) {
-      console.error("Frontend: Caught error object:", err);
-      const errorMessage =
-        err?.message ||
-        (err instanceof Error ? err.message : "An unknown error occurred");
-      setError(errorMessage);
+    if (urlFromParams) {
+      setCurrentSummaryData(null);
       setSubmittedUrl(null);
-      setSummaryData(null);
-    } finally {
-      setIsLoading(false);
+      setRevealedSections([]);
+      setRevealIndex(0);
+      getSummaryMutation.reset();
+      selectHistoryEntry(null);
     }
-  };
+  }, [urlFromParams]);
+
+  useEffect(() => {
+    if (
+      !getSummaryMutation.isPending &&
+      currentSummaryData &&
+      revealIndex < sectionOrder.length
+    ) {
+      const currentKey = sectionOrder[revealIndex];
+      const sectionData = currentSummaryData[currentKey];
+      const shouldReveal =
+        sectionData !== null &&
+        sectionData !== undefined &&
+        (!Array.isArray(sectionData) || sectionData.length > 0);
+
+      if (shouldReveal) {
+        const timer = setTimeout(() => {
+          setRevealedSections((prev) => [...prev, currentKey]);
+          setRevealIndex((prev) => prev + 1);
+        }, 300);
+        return () => clearTimeout(timer);
+      }
+      setRevealIndex((prev) => prev + 1);
+    }
+  }, [currentSummaryData, getSummaryMutation.isPending, revealIndex]);
+
+  useEffect(() => {
+    if (selectedEntry) {
+      setCurrentSummaryData(selectedEntry.summary);
+      setSubmittedUrl(selectedEntry.url);
+      setRevealedSections(
+        sectionOrder.filter(
+          (key) =>
+            selectedEntry.summary[key] !== null &&
+            selectedEntry.summary[key] !== undefined &&
+            (!Array.isArray(selectedEntry.summary[key]) ||
+              (selectedEntry.summary[key] as any[]).length > 0)
+        )
+      );
+      setRevealIndex(sectionOrder.length);
+      form.setValue("url", selectedEntry.url);
+      getSummaryMutation.reset();
+    }
+  }, [selectedEntry, form, getSummaryMutation]);
+
+  const handleSubmit = useCallback(
+    async (values: SummaryFormValues) => {
+      console.log("Submitting URL:", values.url);
+      setCurrentSummaryData(null);
+      setSubmittedUrl(values.url);
+      setRevealedSections([]);
+      setRevealIndex(0);
+      selectHistoryEntry(null);
+      getSummaryMutation.reset();
+
+      try {
+        const result = await getSummaryMutation.mutateAsync({
+          redditUrl: values.url,
+        });
+        console.log("Received summary data:", result);
+        setCurrentSummaryData(result);
+
+        const newEntry: HistoryEntry = {
+          id: `${Date.now()}-${values.url}`,
+          url: values.url,
+          title: result.stats?.subreddit
+            ? `${result.stats.subreddit} - ${result.stats.op || "Summary"}`
+            : new URL(values.url).pathname.split("/")[2] || "Reddit Summary",
+          timestamp: Date.now(),
+          summary: result,
+        };
+        addHistoryEntry(newEntry);
+      } catch (error) {
+        console.error("Mutation failed:", error);
+      }
+    },
+    [getSummaryMutation, addHistoryEntry, selectHistoryEntry]
+  );
 
   return (
-    <div className="flex flex-col min-h-screen">
-      <SimpleHeader />
-      <main className="flex-1 container mx-auto py-12 px-4 md:px-6">
-        <div className="max-w-2xl mx-auto space-y-6">
-          <h1 className="text-3xl font-bold tracking-tight text-center">
-            Reddit Thread Summarizer
-          </h1>
-          <p className="text-muted-foreground text-center">
-            Paste the URL of a Reddit thread below to get a quick summary.
-          </p>
+    <div className="container mx-auto px-4 py-8 max-w-3xl">
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">DigestIt</h1>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => setIsHistoryPanelOpen(true)}
+          aria-label="View History"
+        >
+          <History className="h-5 w-5" />
+        </Button>
+      </div>
 
-          <SummaryForm onSubmit={handleSummarize} isLoading={isLoading} />
+      <form
+        onSubmit={form.handleSubmit(handleSubmit)}
+        className="flex gap-2 mb-6"
+      >
+        <Input
+          {...form.register("url")}
+          placeholder="Paste Reddit thread URL (e.g., reddit.com/r/.../comments/...)"
+          className="flex-grow"
+          disabled={getSummaryMutation.isPending}
+        />
+        <Button
+          type="submit"
+          disabled={getSummaryMutation.isPending || !form.formState.isValid}
+        >
+          {getSummaryMutation.isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : null}
+          {getSummaryMutation.isPending ? "Summarizing..." : "Summarize"}
+        </Button>
+      </form>
 
-          {error && <p className="text-red-500 text-center">Error: {error}</p>}
+      {form.formState.errors.url && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Invalid URL</AlertTitle>
+          <AlertDescription>
+            {form.formState.errors.url.message}
+          </AlertDescription>
+        </Alert>
+      )}
 
-          {isLoading && !summaryData && (
-            <div className="flex justify-center items-center pt-8">
-              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-              <p className="ml-2 text-muted-foreground">
-                Generating summary...
-              </p>
-            </div>
-          )}
+      {getSummaryMutation.error && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>
+            {getSummaryMutation.error.message ||
+              "An unknown error occurred while fetching the summary."}
+          </AlertDescription>
+        </Alert>
+      )}
 
-          {summaryData && (
-            <SummaryCard
-              summaryData={summaryData}
-              submittedUrl={submittedUrl}
-              isLoading={isLoading}
-              revealedSections={revealedSections}
-              sectionOrder={sectionOrder}
-              renderChunk={renderChunk}
-            />
-          )}
-        </div>
-      </main>
+      {(getSummaryMutation.isPending || currentSummaryData) && (
+        <SummaryCard
+          summaryData={currentSummaryData!}
+          submittedUrl={submittedUrl}
+          isLoading={getSummaryMutation.isPending}
+          revealedSections={revealedSections}
+          sectionOrder={sectionOrder}
+          renderChunk={renderChunk}
+        />
+      )}
+
+      <HistoryPanel
+        isOpen={isHistoryPanelOpen}
+        onOpenChange={setIsHistoryPanelOpen}
+      />
     </div>
+  );
+}
+
+export default function SummaryPage() {
+  return (
+    <HistoryProvider>
+      <SummaryPageContent />
+    </HistoryProvider>
   );
 }

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -119,7 +119,7 @@ function SummaryPageContent() {
       form.setValue("url", selectedEntry.url);
       getSummaryMutation.reset();
     }
-  }, [selectedEntry, form, getSummaryMutation]);
+  }, [selectedEntry]);
 
   const handleSubmit = useCallback(
     async (values: SummaryFormValues) => {

--- a/components/history/HistoryPanel.tsx
+++ b/components/history/HistoryPanel.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useHistory } from "@/contexts/HistoryContext";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter,
+  SheetClose,
+} from "@/components/ui/sheet";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { HistoryEntry } from "@/lib/types/historyTypes";
+import { Trash2 } from "lucide-react";
+import { truncateUrl } from "@/lib/utils/stringUtils";
+import { formatDistanceToNow } from "date-fns";
+
+interface HistoryPanelProps {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+}
+
+export default function HistoryPanel({
+  isOpen,
+  onOpenChange,
+}: HistoryPanelProps) {
+  const { history, selectHistoryEntry, clearHistory, selectedEntry } =
+    useHistory();
+
+  const handleSelect = (entry: HistoryEntry) => {
+    selectHistoryEntry(entry);
+    onOpenChange(false); // Close panel on selection
+  };
+
+  const handleClear = () => {
+    clearHistory();
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetContent className="flex flex-col">
+        <SheetHeader>
+          <SheetTitle>History</SheetTitle>
+          <SheetDescription>
+            View summaries of previously analyzed Reddit threads.
+          </SheetDescription>
+        </SheetHeader>
+        <ScrollArea className="flex-grow my-4 pr-3">
+          {history.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-10">
+              No history yet.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {history.map((entry) => (
+                <Button
+                  key={entry.id}
+                  variant={
+                    selectedEntry?.id === entry.id ? "secondary" : "ghost"
+                  }
+                  className="w-full h-auto justify-start text-left p-3 flex flex-col items-start"
+                  onClick={() => handleSelect(entry)}
+                >
+                  <span className="font-medium truncate block w-full">
+                    {entry.title}
+                  </span>
+                  <span className="text-xs text-muted-foreground truncate block w-full">
+                    {truncateUrl(entry.url, 50)}
+                  </span>
+                  <span className="text-xs text-muted-foreground/80 block w-full mt-0.5">
+                    {formatDistanceToNow(entry.timestamp, { addSuffix: true })}
+                  </span>
+                </Button>
+              ))}
+            </div>
+          )}
+        </ScrollArea>
+        <SheetFooter className="mt-auto pt-4 border-t">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleClear}
+            disabled={history.length === 0}
+            className="w-full"
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            Clear History
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          side === "right" &&
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+          side === "left" &&
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+          side === "top" &&
+            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+          side === "bottom" &&
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <XIcon className="size-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/contexts/HistoryContext.tsx
+++ b/contexts/HistoryContext.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React, {
+  createContext,
+  useState,
+  useContext,
+  ReactNode,
+  useEffect,
+} from "react";
+import { HistoryEntry } from "@/lib/types/historyTypes";
+import {
+  loadHistory,
+  addHistoryEntry as saveEntry,
+  clearHistory as clearStorage,
+} from "@/lib/utils/historyStorage";
+
+interface HistoryContextType {
+  history: HistoryEntry[];
+  selectedEntry: HistoryEntry | null;
+  addHistoryEntry: (entry: HistoryEntry) => void;
+  selectHistoryEntry: (entry: HistoryEntry | null) => void;
+  clearHistory: () => void;
+}
+
+const HistoryContext = createContext<HistoryContextType | undefined>(undefined);
+
+export const HistoryProvider = ({ children }: { children: ReactNode }) => {
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [selectedEntry, setSelectedEntry] = useState<HistoryEntry | null>(null);
+
+  // Load history on mount
+  useEffect(() => {
+    setHistory(loadHistory());
+  }, []);
+
+  const addEntry = (entry: HistoryEntry) => {
+    const updatedHistory = saveEntry(entry);
+    setHistory(updatedHistory);
+    setSelectedEntry(null); // Deselect any historical entry when adding a new one
+  };
+
+  const selectEntry = (entry: HistoryEntry | null) => {
+    setSelectedEntry(entry);
+  };
+
+  const clear = () => {
+    clearStorage();
+    setHistory([]);
+    setSelectedEntry(null);
+  };
+
+  return (
+    <HistoryContext.Provider
+      value={{
+        history,
+        selectedEntry,
+        addHistoryEntry: addEntry,
+        selectHistoryEntry: selectEntry,
+        clearHistory: clear,
+      }}
+    >
+      {children}
+    </HistoryContext.Provider>
+  );
+};
+
+export const useHistory = () => {
+  const context = useContext(HistoryContext);
+  if (context === undefined) {
+    throw new Error("useHistory must be used within a HistoryProvider");
+  }
+  return context;
+};

--- a/lib/types/historyTypes.ts
+++ b/lib/types/historyTypes.ts
@@ -1,0 +1,9 @@
+import { SummaryData } from "./summaryTypes";
+
+export interface HistoryEntry {
+  id: string; // Unique ID, could be timestamp + url hash
+  url: string;
+  title: string; // Extracted from summary or URL
+  timestamp: number; // Unix timestamp
+  summary: SummaryData;
+}

--- a/lib/utils/historyStorage.ts
+++ b/lib/utils/historyStorage.ts
@@ -1,0 +1,71 @@
+import { HistoryEntry } from "../types/historyTypes";
+
+const HISTORY_KEY = "digestItHistory";
+
+export function loadHistory(): HistoryEntry[] {
+  if (typeof window === "undefined") {
+    return []; // Don't run on server
+  }
+  try {
+    const stored = localStorage.getItem(HISTORY_KEY);
+    if (!stored) {
+      return [];
+    }
+    const parsed = JSON.parse(stored) as HistoryEntry[];
+    // Basic validation (can be improved)
+    if (!Array.isArray(parsed)) {
+      console.error("Invalid history data found in local storage. Clearing.");
+      localStorage.removeItem(HISTORY_KEY);
+      return [];
+    }
+    return parsed.sort((a, b) => b.timestamp - a.timestamp); // Show newest first
+  } catch (error) {
+    console.error("Failed to load history from local storage:", error);
+    return [];
+  }
+}
+
+export function saveHistory(history: HistoryEntry[]) {
+  if (typeof window === "undefined") {
+    return; // Don't run on server
+  }
+  try {
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+  } catch (error) {
+    console.error("Failed to save history to local storage:", error);
+  }
+}
+
+export function addHistoryEntry(entry: HistoryEntry): HistoryEntry[] {
+  const currentHistory = loadHistory();
+  // Prevent duplicates based on URL
+  const existingIndex = currentHistory.findIndex(
+    (item) => item.url === entry.url
+  );
+  if (existingIndex !== -1) {
+    // Update existing entry's timestamp and summary
+    currentHistory[existingIndex] = entry;
+  } else {
+    currentHistory.push(entry);
+  }
+  // Optional: Limit history size
+  const maxHistorySize = 50;
+  if (currentHistory.length > maxHistorySize) {
+    currentHistory.sort((a, b) => b.timestamp - a.timestamp);
+    currentHistory.length = maxHistorySize;
+  }
+
+  saveHistory(currentHistory);
+  return loadHistory(); // Return the updated, sorted history
+}
+
+export function clearHistory() {
+  if (typeof window === "undefined") {
+    return; // Don't run on server
+  }
+  try {
+    localStorage.removeItem(HISTORY_KEY);
+  } catch (error) {
+    console.error("Failed to clear history from local storage:", error);
+  }
+}


### PR DESCRIPTION
This pull request introduces a new feature allowing users to view a history of their previously generated Reddit thread summaries. The history is stored locally using the browser's `localStorage`.

## Key Changes:
- History Data Structure: Defined the `HistoryEntry` interface in `lib/types/historyTypes.ts`.
- Local Storage Persistence: Implemented utility functions (`loadHistory`, `saveHistory`, `addHistoryEntry`, `clearHistory`) in `lib/utils/historyStorage.ts` to manage history data in ``localStorage``. History is sorted newest-first and prevents duplicates based on URL (updates existing entries).
- Global State Management: Introduced `HistoryContext` (`contexts/HistoryContext.tsx`) using React Context API to manage the `historyEntries` array and the currently selected historical entry across components.
- UI - History Panel: Created the `HistoryPanel` component (`components/history/HistoryPanel.tsx`) using `shadcn/ui`'s `Sheet` component. This provides a collapsible side panel displaying the list of historical entries with timestamps (using `date-fns`). Includes functionality to select an entry or clear the entire history.

## UI - Integration:
- Integrated the `HistoryProvider` into `app/summary/page.tsx`.
- Added a "History" button (using `Lucide icon`) to the main page to toggle the `HistoryPanel`.
- Modified the summary page logic to save successfully generated summaries to the history via `addHistoryEntry` from the context.
- Updated the summary page to display the selected historical summary data (`selectedEntry` from context) when an item is clicked in the `HistoryPanel`.